### PR TITLE
docs(readme): remove unnecessary "git add" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Since Angular 12, the CLI option has been renamed to `--lint-file-patterns`. Use
 ```json
 {
   "lint-staged": {
-    "src/**/*.ts": ["ng-lint-staged lint --fix --", "git add"]
+    "src/**/*.ts": ["ng-lint-staged lint --fix"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Since Angular 12, the CLI option has been renamed to `--lint-file-patterns`. Use
 ```json
 {
   "lint-staged": {
-    "src/**/*.ts": ["ng-lint-staged lint --fix"]
+    "src/**/*.ts": ["ng-lint-staged lint --fix --"]
   }
 }
 ```


### PR DESCRIPTION
This change will prevent users from seeing the following error message

```bash
⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
```